### PR TITLE
Fixing being able to use several DAESolver

### DIFF
--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -197,6 +197,10 @@ class DAESolver(OptionsManager):
         post_f_callback = kwargs.get("post_function_callback")
         monitor_callback = kwargs.get("monitor_callback")
 
+        self.nullspace = nullspace
+        self.near_nullspace = near_nullspace
+        self.nullspace_T = nullspace_T
+
         super(DAESolver, self).__init__(parameters, options_prefix)
 
         # Allow anything, interpret "matfree" as matrix_free.
@@ -245,6 +249,31 @@ class DAESolver(OptionsManager):
         # allow a certain number of failures (step will be rejected and retried)
         self.set_default_parameter("ts_max_snes_failures", 5)
 
+        self._set_problem(ctx, problem, nullspace, nullspace_T, near_nullspace)
+
+        # Set from options now. We need the
+        # DM with an app context in place so that if the DM is active
+        # on a subKSP the context is available.
+        dm = self.ts.getDM()
+        with dmhooks.add_hooks(dm, self, appctx=self._ctx, save=False):
+            self.set_from_options(self.ts)
+
+        # Used for custom grid transfer.
+        self._transfer_operators = ()
+        self._setup = False
+
+    def _set_problem(self, ctx, problem, nullspace, nullspace_T, near_nullspace):
+        r"""
+        :arg problem: A :class:`DAEProblem` to solve.
+        :arg ctx: A :class:`_TSContext` that contains the residual evaluations
+        :arg nullspace: an optional :class:`.VectorSpaceBasis` (or
+               :class:`.MixedVectorSpaceBasis`) spanning the null
+               space of the operator.
+        :arg nullspace_T: as for the nullspace, but used to
+               make the right hand side consistent.
+        :arg near_nullspace: as for the nullspace, but used to
+               specify the near nullspace (for multigrid solvers).
+        """
         ctx.set_ifunction(self.ts)
         ctx.set_ijacobian(self.ts)
         ctx.set_nullspace(
@@ -269,17 +298,6 @@ class DAESolver(OptionsManager):
         ctx._nullspace_T = nullspace_T
         ctx._near_nullspace = near_nullspace
 
-        # Set from options now. We need the
-        # DM with an app context in place so that if the DM is active
-        # on a subKSP the context is available.
-        dm = self.ts.getDM()
-        with dmhooks.add_hooks(dm, self, appctx=self._ctx, save=False):
-            self.set_from_options(self.ts)
-
-        # Used for custom grid transfer.
-        self._transfer_operators = ()
-        self._setup = False
-
     def set_transfer_manager(self, manager):
         r"""Set the object that manages transfer between grid levels.
         Typically a :class:`~.TransferManager` object.
@@ -298,6 +316,14 @@ class DAESolver(OptionsManager):
            If bounds are provided the ``snes_type`` must be set to
            ``vinewtonssls`` or ``vinewtonrsls``.
         """
+
+        self._set_problem(
+            self._ctx,
+            self._problem,
+            self.nullspace,
+            self.nullspace_T,
+            self.near_nullspace,
+        )
         # Make sure appcontext is attached to the DM before we solve.
         dm = self.ts.getDM()
         for dbc in self._problem.dirichlet_bcs():

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -249,7 +249,7 @@ class DAESolver(OptionsManager):
         # allow a certain number of failures (step will be rejected and retried)
         self.set_default_parameter("ts_max_snes_failures", 5)
 
-        self._set_problem(ctx, problem, nullspace, nullspace_T, near_nullspace)
+        self._set_problem_eval_funcs(ctx, problem, nullspace, nullspace_T, near_nullspace)
 
         # Set from options now. We need the
         # DM with an app context in place so that if the DM is active
@@ -262,7 +262,7 @@ class DAESolver(OptionsManager):
         self._transfer_operators = ()
         self._setup = False
 
-    def _set_problem(self, ctx, problem, nullspace, nullspace_T, near_nullspace):
+    def _set_problem_eval_funcs(self, ctx, problem, nullspace, nullspace_T, near_nullspace):
         r"""
         :arg problem: A :class:`DAEProblem` to solve.
         :arg ctx: A :class:`_TSContext` that contains the residual evaluations
@@ -317,7 +317,7 @@ class DAESolver(OptionsManager):
            ``vinewtonssls`` or ``vinewtonrsls``.
         """
 
-        self._set_problem(
+        self._set_problem_eval_funcs(
             self._ctx,
             self._problem,
             self.nullspace,

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -356,7 +356,7 @@ class DAESolver(OptionsManager):
     def adjoint_solve(self):
         r"""Solve the adjoint problem.
         """
-        self._set_problem(
+        self._set_problem_eval_funcs(
             self._ctx,
             self._problem,
             self.nullspace,

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -249,7 +249,9 @@ class DAESolver(OptionsManager):
         # allow a certain number of failures (step will be rejected and retried)
         self.set_default_parameter("ts_max_snes_failures", 5)
 
-        self._set_problem_eval_funcs(ctx, problem, nullspace, nullspace_T, near_nullspace)
+        self._set_problem_eval_funcs(
+            ctx, problem, nullspace, nullspace_T, near_nullspace
+        )
 
         # Set from options now. We need the
         # DM with an app context in place so that if the DM is active
@@ -262,7 +264,9 @@ class DAESolver(OptionsManager):
         self._transfer_operators = ()
         self._setup = False
 
-    def _set_problem_eval_funcs(self, ctx, problem, nullspace, nullspace_T, near_nullspace):
+    def _set_problem_eval_funcs(
+        self, ctx, problem, nullspace, nullspace_T, near_nullspace
+    ):
         r"""
         :arg problem: A :class:`DAEProblem` to solve.
         :arg ctx: A :class:`_TSContext` that contains the residual evaluations

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -356,6 +356,13 @@ class DAESolver(OptionsManager):
     def adjoint_solve(self):
         r"""Solve the adjoint problem.
         """
+        self._set_problem(
+            self._ctx,
+            self._problem,
+            self.nullspace,
+            self.nullspace_T,
+            self.near_nullspace,
+        )
         # Make sure appcontext is attached to the DM before the adjoint solve.
         dm = self.ts.getDM()
 

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -268,8 +268,8 @@ class DAESolver(OptionsManager):
         self, ctx, problem, nullspace, nullspace_T, near_nullspace
     ):
         r"""
-        :arg problem: A :class:`DAEProblem` to solve.
         :arg ctx: A :class:`_TSContext` that contains the residual evaluations
+        :arg problem: A :class:`DAEProblem` to solve.
         :arg nullspace: an optional :class:`.VectorSpaceBasis` (or
                :class:`.MixedVectorSpaceBasis`) spanning the null
                space of the operator.

--- a/tests/test_two_daesolver.py
+++ b/tests/test_two_daesolver.py
@@ -1,0 +1,37 @@
+import pytest
+from firedrake import *
+import firedrake_ts
+
+
+def test_two_ts():
+    mesh = UnitIntervalMesh(10)
+    V = FunctionSpace(mesh, "P", 1)
+
+    u = Function(V)
+    u_t = Function(V)
+    v = TestFunction(V)
+    F = inner(u_t, v) * dx + inner(grad(u), grad(v)) * dx - 1.0 * v * dx
+
+    bc = DirichletBC(V, 0.0, "on_boundary")
+
+    x = SpatialCoordinate(mesh)
+    bump = conditional(lt(abs(x[0] - 0.5), 0.1), 1.0, 0.0)
+    u.interpolate(bump)
+
+
+    dt = 2e-2
+    problem = firedrake_ts.DAEProblem(F, u, u_t, (0.0, 1.0), bcs=bc)
+    solver = firedrake_ts.DAESolver(problem)
+
+    V2 = FunctionSpace(mesh, "P", 1)
+    u2 = Function(V2)
+    u_t2 = Function(V2)
+    v = TestFunction(V2)
+    F2 = inner(u_t2, v) * dx + inner(grad(u2), grad(v)) * dx - 1.0 * v * dx
+    bc2 = DirichletBC(V2, 0.0, "on_boundary")
+
+
+    problem2 = firedrake_ts.DAEProblem(F2, u2, u_t2, (0.0, 1.0), bcs=bc2)
+    solver2 = firedrake_ts.DAESolver(problem2)
+
+    solver.solve()

--- a/tests/test_two_daesolver.py
+++ b/tests/test_two_daesolver.py
@@ -18,7 +18,6 @@ def test_two_ts():
     bump = conditional(lt(abs(x[0] - 0.5), 0.1), 1.0, 0.0)
     u.interpolate(bump)
 
-
     problem = firedrake_ts.DAEProblem(F, u, u_t, (0.0, 1.0), bcs=bc)
     solver = firedrake_ts.DAESolver(problem)
 
@@ -29,8 +28,7 @@ def test_two_ts():
     F2 = inner(u_t2, v) * dx + inner(grad(u2), grad(v)) * dx - 1.0 * v * dx
     bc2 = DirichletBC(V2, 0.0, "on_boundary")
 
-
     problem2 = firedrake_ts.DAEProblem(F2, u2, u_t2, (0.0, 1.0), bcs=bc2)
-    solver2 = firedrake_ts.DAESolver(problem2)
+    solver2 = firedrake_ts.DAESolver(problem2)  # noqa: F841
 
     solver.solve()

--- a/tests/test_two_daesolver.py
+++ b/tests/test_two_daesolver.py
@@ -19,7 +19,6 @@ def test_two_ts():
     u.interpolate(bump)
 
 
-    dt = 2e-2
     problem = firedrake_ts.DAEProblem(F, u, u_t, (0.0, 1.0), bcs=bc)
     solver = firedrake_ts.DAESolver(problem)
 

--- a/tests/test_two_daesolver.py
+++ b/tests/test_two_daesolver.py
@@ -4,6 +4,9 @@ import firedrake_ts
 
 
 def test_two_ts():
+    """
+    A test for issue #4 https://github.com/IvanYashchuk/firedrake-ts/issues/4
+    """
     mesh = UnitIntervalMesh(10)
     V = FunctionSpace(mesh, "P", 1)
 
@@ -31,4 +34,7 @@ def test_two_ts():
     problem2 = firedrake_ts.DAEProblem(F2, u2, u_t2, (0.0, 1.0), bcs=bc2)
     solver2 = firedrake_ts.DAESolver(problem2)  # noqa: F841
 
+    # Now, after defining solver2, solver.solve() shouldn't raise any errors
     solver.solve()
+
+    solver2.solve()


### PR DESCRIPTION
This addresses #4 and firedrakeproject/firedrake#1757 (see last one for more details of what is going on). This functionality is important to be able to use different `DAESolver` or in combination with `NonlinearVariationalSolver`.