### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Python info
-        shell: bash -l {0}
+        shell: bash
         run: |
           source /home/firedrake/firedrake/bin/activate
           which python
@@ -27,7 +27,7 @@ jobs:
           python -c "from firedrake import *"
 
       - name: Install dependencies
-        shell: bash -l {0}
+        shell: bash
         run: |
           source /home/firedrake/firedrake/bin/activate
           python -m pip install --upgrade pip
@@ -37,13 +37,13 @@ jobs:
           python -m pip install coveralls
 
       - name: Install firedrake-ts
-        shell: bash -l {0}
+        shell: bash
         run: |
           source /home/firedrake/firedrake/bin/activate
           python -m pip install -e .
 
       - name: Test with pytest
-        shell: bash -l {0}
+        shell: bash
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |


### PR DESCRIPTION
Remove discarding the default shell options with `{0}`.
Previously the shell exited with the exit code of the last command executed in a script, so the CI step could mark as successful even if pytest failed.