### PR TITLE
Compatibility fix for Firedrake `2024-12` Docker image

### DIFF
--- a/examples/adjoint.py
+++ b/examples/adjoint.py
@@ -14,7 +14,8 @@ V = fd.VectorFunctionSpace(mesh, "CG", 2)
 
 x = ufl.SpatialCoordinate(mesh)
 expr = ufl.as_vector([ufl.sin(2 * ufl.pi * x[0]), ufl.cos(2 * ufl.pi * x[1])])
-u = fd.interpolate(expr, V)
+u = fd.Function(V)
+u.interpolate(expr)
 
 u_dot = fd.Function(V)
 v = fd.TestFunction(V)

--- a/examples/adjoint.py
+++ b/examples/adjoint.py
@@ -36,7 +36,7 @@ t = 0.0
 end = 0.1
 tspan = (t, end)
 
-state_out = fd.File("result/state.pvd")
+state_out = fd.output.VTKFile("result/state.pvd")
 
 
 def ts_monitor(ts, steps, time, X):
@@ -82,5 +82,5 @@ fdJdu=dJdu.riesz_representation()
 print(f"Norm of dJdu after the adjoint solve: {dJdu_vec.norm()=} {fd.norm(fdJdu)=}")
 
 
-adj_out = fd.File("result/adj.pvd")
+adj_out = fd.output.VTKFile("result/adj.pvd")
 adj_out.write(fdJdu, time=0)

--- a/examples/burgers.py
+++ b/examples/burgers.py
@@ -24,7 +24,7 @@ F = (
     inner(u_t, v) + inner(dot(u, nabla_grad(u)), v) + nu * inner(grad(u), grad(v))
 ) * dx
 
-outfile = File("result/burgers.pvd")
+outfile = output.VTKFile("result/burgers.pvd")
 outfile.write(project(u, V_out, name="Velocity"), time=0.0)
 
 

--- a/firedrake_ts/solving_utils.py
+++ b/firedrake_ts/solving_utils.py
@@ -3,7 +3,6 @@ from itertools import chain
 import numpy
 
 from pyop2 import op2
-from firedrake_configuration import get_config
 from firedrake import function, cofunction, dmhooks
 from firedrake.exceptions import ConvergenceError
 from firedrake.petsc import PETSc

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -83,6 +83,7 @@ class DAEProblem(object):
 
         self.u = u
         self.udot = udot
+        self.u_restrict = udot
         self.tspan = tspan
         self.F = F
         self.G = G

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -87,7 +87,6 @@ class DAEProblem(object):
         self.F = F
         self.G = G
         self.Jp = Jp
-        self.restrict = False
 
         if not isinstance(self.u_restrict, function.Function):
             raise TypeError(

--- a/firedrake_ts/ts_solver.py
+++ b/firedrake_ts/ts_solver.py
@@ -228,6 +228,7 @@ class DAESolver(OptionsManager):
             # Mixed problem, use jacobi pc if user has not supplied
             # one.
             self.set_default_parameter("pc_type", "jacobi")
+        self.set_default_parameter("ts_max_snes_failures", -1)
 
         self.ts = PETSc.TS().create(comm=problem.dm.comm)
         self.snes = self.ts.getSNES()


### PR DESCRIPTION
This PR removes the (actually unused) import of `firedrake_configuration` package that is no longer present in recent (2 weeks or so) versions of [Firedrake Docker Hub image](https://hub.docker.com/r/firedrakeproject/firedrake/tags).

Root cause of the issue is the migration of Firedrake to be `pip`-installable. There's details about the topic [here](https://github.com/firedrakeproject/firedrake/issues/3877). Specifically, the problem started with [the PR that migrates _PyOP2_ into the main _Firedrake_ repo](https://github.com/firedrakeproject/firedrake/pull/3817).

---

It seems like the obvious fix, i.e. just remove the import, worked. The `firedrake_configuration` module wasn't used for anything directly within the `firedrake_ts` package. Besides this, the PR contains a few small fixes to make the unit tests and examples work.

It seems like PETSc 3.22 upgrage that's bundled in the Firedrake 2024-12 image doesn't set the [`ts_max_snes_failures`](https://petsc.org/release/manualpages/TS/TSSetMaxSNESFailures/) option anymore. Somehow the default value causes the inner SNES solver never to retry any linear solves. So the TS solver has no other option but to fail whenever it happens instead of retrying.

I also migrated the example applications to use the newer interpolate and VTK output Firedrake API.